### PR TITLE
feat(components): ポートフォリオヘッダーコンポーネントの作成

### DIFF
--- a/frontend/src/components/PortfolioHeader/Portfolio.react.test.tsx
+++ b/frontend/src/components/PortfolioHeader/Portfolio.react.test.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { PortfolioHeader } from "./PortfolioHeader";
+
+test("Portfolio sample test", () => {
+  const component = renderer.create(
+    <PortfolioHeader headerTitle="test" navigationElements={[]} />
+  );
+  let tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/frontend/src/components/PortfolioHeader/PortfolioHeader.tsx
+++ b/frontend/src/components/PortfolioHeader/PortfolioHeader.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import AppBar from "@material-ui/core/AppBar";
+import Toolbar from "@material-ui/core/Toolbar";
+import Typography from "@material-ui/core/Typography";
+import NavigationElement from "../../models/NavigationElement";
+import "./style.scss";
+
+export interface HeaderProps {
+  headerTitle: string;
+  navigationElements: NavigationElement[];
+}
+
+export class PortfolioHeader extends React.Component<HeaderProps> {
+  render() {
+    return (
+      <>
+        <AppBar position="static" color="primary">
+          <Toolbar>
+            <Typography variant="h3">{this.props.headerTitle}</Typography>
+          </Toolbar>
+          <Toolbar>
+            <ul>
+              {this.props.navigationElements.map((e) => {
+                return <li>{e.elementName}</li>;
+              })}
+            </ul>
+          </Toolbar>
+        </AppBar>
+      </>
+    );
+  }
+}

--- a/frontend/src/components/PortfolioHeader/style.scss
+++ b/frontend/src/components/PortfolioHeader/style.scss
@@ -1,0 +1,10 @@
+ul {
+  li {
+    display: inline;
+    margin: 0 10px;
+
+    &:hover {
+      color: orange;
+    }
+  }
+}

--- a/frontend/src/models/NavigationElement.ts
+++ b/frontend/src/models/NavigationElement.ts
@@ -1,0 +1,4 @@
+export default interface NavigationElement {
+  elementName: string;
+  elementUrl: string;
+}

--- a/frontend/src/stories/PortfolioHeader.stories.tsx
+++ b/frontend/src/stories/PortfolioHeader.stories.tsx
@@ -1,0 +1,42 @@
+import { Story, Meta } from "@storybook/react";
+import {
+  PortfolioHeader,
+  HeaderProps,
+} from "../components/PortfolioHeader/PortfolioHeader";
+import NavigationElements from "../models/NavigationElement";
+
+const mockNavigationElements = [
+  {
+    elementName: "testElement",
+    elemenUrl: "",
+  },
+  {
+    elementName: "testElement2",
+    elementUrl: "",
+  },
+] as NavigationElements[];
+
+export default {
+  title: "Example/PortfolioHeader",
+  component: PortfolioHeader,
+  argTypes: {
+    headerTitle: { control: "text" },
+    navigationElements: {
+      types: "array",
+    },
+  },
+} as Meta;
+
+const Template: Story<HeaderProps> = (args) => <PortfolioHeader {...args} />;
+
+export const Title = Template.bind({});
+Title.args = {
+  headerTitle: "Title",
+  navigationElements: [],
+};
+
+export const Elements = Template.bind({});
+Elements.args = {
+  headerTitle: "",
+  navigationElements: mockNavigationElements,
+};


### PR DESCRIPTION
## 概要
[ポートフォリオのヘッダー部分](https://github.com/kouta0530/my-portfolio/issues/1)の作成

|名前| image |
|---| --- |
| 実装後 | ![スクリーンショット 2021-06-02 21-29-25](https://user-images.githubusercontent.com/38244340/120480157-b7993700-c3e9-11eb-94aa-0adb197d1881.png) |

## 要件
- [x] サイトのタイトルを表示できる
- [x] ナビゲーションの要素を表示できる
- [x] ナビゲーションの内容などを動的に変更できる  

## 補足
各コンポーネントができた際にナビゲーションをクリックした時の挙動を追加する
