### PR TITLE
feat(components): コンタクトコンポーネントの作成

### DIFF
--- a/frontend/src/components/PortfolioContact/PortfolioContact.react.test.tsx
+++ b/frontend/src/components/PortfolioContact/PortfolioContact.react.test.tsx
@@ -1,0 +1,50 @@
+import PortfolioContact from "./PortfolioContact";
+import renderer from "react-test-renderer";
+
+test("PortfolioContact Title Props Test", () => {
+  const component = renderer.create(
+    <PortfolioContact
+      contactHeaderTitle="TestTitle"
+      contentIcons={[]}
+      contentText={[]}
+    />
+  );
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test("Portfolio Contact Icons Props Test", () => {
+  const mockContentIcons = [
+    {
+      iconName: "testIcon",
+      contentUrl: "",
+      iconImagePath: "logo192.png",
+    },
+  ];
+
+  const component = renderer.create(
+    <PortfolioContact
+      contactHeaderTitle=""
+      contentIcons={mockContentIcons}
+      contentText={[]}
+    />
+  );
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test("Portfolio Contact content Text Prop Test", () => {
+  const mockTexts = ["test", "test2"];
+  const component = renderer.create(
+    <PortfolioContact
+      contactHeaderTitle=""
+      contentIcons={[]}
+      contentText={mockTexts}
+    />
+  );
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/frontend/src/components/PortfolioContact/PortfolioContact.tsx
+++ b/frontend/src/components/PortfolioContact/PortfolioContact.tsx
@@ -21,7 +21,9 @@ export default class PortfolioContact extends React.Component<ContactPrams> {
           </div>
           <div className="content-icons">
             {this.props.contentIcons.map((e) => (
-              <img src={e.iconImagePath} alt={e.iconName} />
+              <a href={e.contentUrl}>
+                <img src={e.iconImagePath} alt={e.iconName} />
+              </a>
             ))}
           </div>
           <div className="content-texts">

--- a/frontend/src/components/PortfolioContact/PortfolioContact.tsx
+++ b/frontend/src/components/PortfolioContact/PortfolioContact.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import IconParameter from "../../models/IconParameter";
 import Typography from "@material-ui/core/Typography";
+import "./style.scss";
 
 type ContactPrams = {
   contactHeaderTitle: String;
@@ -12,8 +13,13 @@ export default class PortfolioContact extends React.Component<ContactPrams> {
   render() {
     return (
       <>
-        <div>
+        <div className="contact-title">
           <Typography variant="h4">{this.props.contactHeaderTitle}</Typography>
+        </div>
+        <div className="content-icons">
+          {this.props.contentIcons.map((e) => (
+            <img src={e.iconImagePath} alt={e.iconName} />
+          ))}
         </div>
       </>
     );

--- a/frontend/src/components/PortfolioContact/PortfolioContact.tsx
+++ b/frontend/src/components/PortfolioContact/PortfolioContact.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import IconParameter from "../../models/IconParameter";
+import Typography from "@material-ui/core/Typography";
+
+type ContactPrams = {
+  contactHeaderTitle: String;
+  contentIcons: IconParameter[];
+  contentText: String;
+};
+
+export default class PortfolioContact extends React.Component<ContactPrams> {
+  render() {
+    return (
+      <>
+        <div>
+          <Typography variant="h4">{this.props.contactHeaderTitle}</Typography>
+        </div>
+      </>
+    );
+  }
+}

--- a/frontend/src/components/PortfolioContact/PortfolioContact.tsx
+++ b/frontend/src/components/PortfolioContact/PortfolioContact.tsx
@@ -6,20 +6,29 @@ import "./style.scss";
 type ContactPrams = {
   contactHeaderTitle: String;
   contentIcons: IconParameter[];
-  contentText: String;
+  contentText: String[];
 };
 
 export default class PortfolioContact extends React.Component<ContactPrams> {
   render() {
     return (
       <>
-        <div className="contact-title">
-          <Typography variant="h4">{this.props.contactHeaderTitle}</Typography>
-        </div>
-        <div className="content-icons">
-          {this.props.contentIcons.map((e) => (
-            <img src={e.iconImagePath} alt={e.iconName} />
-          ))}
+        <div className="content">
+          <div className="contact-title">
+            <Typography variant="h4">
+              {this.props.contactHeaderTitle}
+            </Typography>
+          </div>
+          <div className="content-icons">
+            {this.props.contentIcons.map((e) => (
+              <img src={e.iconImagePath} alt={e.iconName} />
+            ))}
+          </div>
+          <div className="content-texts">
+            {this.props.contentText.map((e) => (
+              <p>{e}</p>
+            ))}
+          </div>
         </div>
       </>
     );

--- a/frontend/src/components/PortfolioContact/style.scss
+++ b/frontend/src/components/PortfolioContact/style.scss
@@ -3,7 +3,6 @@
   width: 50%;
 }
 .content {
-  background-color: azure;
   width: 500px;
   margin: 0 auto;
   padding: 10px 0;

--- a/frontend/src/components/PortfolioContact/style.scss
+++ b/frontend/src/components/PortfolioContact/style.scss
@@ -1,0 +1,9 @@
+.contact-title {
+  margin: 0 auto;
+  width: 50%;
+}
+.content-icons {
+  display: flex;
+  margin: 0 auto;
+  width: 50%;
+}

--- a/frontend/src/components/PortfolioContact/style.scss
+++ b/frontend/src/components/PortfolioContact/style.scss
@@ -2,8 +2,23 @@
   margin: 0 auto;
   width: 50%;
 }
-.content-icons {
-  display: flex;
+.content {
+  background-color: azure;
+  width: 500px;
   margin: 0 auto;
-  width: 50%;
+  padding: 10px 0;
+
+  .content-icons {
+    display: flex;
+    justify-content: center;
+
+    img {
+      width: 30%;
+      height: 30%;
+      margin: 1.2em;
+    }
+  }
+  .content-texts {
+    text-align: center;
+  }
 }

--- a/frontend/src/components/PortfolioContact/style.scss
+++ b/frontend/src/components/PortfolioContact/style.scss
@@ -13,8 +13,6 @@
     justify-content: center;
 
     img {
-      width: 30%;
-      height: 30%;
       margin: 1.2em;
     }
   }

--- a/frontend/src/models/IconParameter.ts
+++ b/frontend/src/models/IconParameter.ts
@@ -1,5 +1,5 @@
 export default interface IconParameter {
-  iconName: String;
-  contentUrl: String | "";
-  iconImagePath: String;
+  iconName: string;
+  contentUrl: string | "";
+  iconImagePath: string;
 }

--- a/frontend/src/models/IconParameter.ts
+++ b/frontend/src/models/IconParameter.ts
@@ -1,0 +1,5 @@
+export default interface IconParameter {
+  iconName: String;
+  contentUrl: String | "";
+  iconImagePath: String;
+}

--- a/frontend/src/stories/PortfolioContact.stories.tsx
+++ b/frontend/src/stories/PortfolioContact.stories.tsx
@@ -7,8 +7,11 @@ export default {
   component: PortfolioContact,
   argTypes: {
     contactHeaderTitle: { control: "text" },
-    contactIcons: {
+    contentIcons: {
       types: "array",
+    },
+    contentText: {
+      control: "array",
     },
   },
 } as Meta;
@@ -43,4 +46,17 @@ Default.args = {
   contactHeaderTitle: "TestContactTitle",
   contentIcons: mockContentIcons,
   contentText: mockContentText,
+};
+
+export const Title = Template.bind({});
+Title.args = {
+  contactHeaderTitle: "TestContactTitle",
+  contentIcons: [],
+  contentText: [],
+};
+
+export const Icons = Template.bind({});
+Icons.args = {
+  contentIcons: mockContentIcons,
+  contentText: [],
 };

--- a/frontend/src/stories/PortfolioContact.stories.tsx
+++ b/frontend/src/stories/PortfolioContact.stories.tsx
@@ -16,7 +16,7 @@ export default {
 type ContactPrams = {
   contactHeaderTitle: String;
   contentIcons: IconParameter[];
-  contentText: String;
+  contentText: String[];
 };
 
 const mockContentIcons = [
@@ -32,6 +32,8 @@ const mockContentIcons = [
   },
 ];
 
+const mockContentText = ["test@example.com"];
+
 const Template: Story<ContactPrams> = (args) => (
   <PortfolioContact {...args}> /</PortfolioContact>
 );
@@ -40,4 +42,5 @@ export const Default = Template.bind({});
 Default.args = {
   contactHeaderTitle: "TestContactTitle",
   contentIcons: mockContentIcons,
+  contentText: mockContentText,
 };

--- a/frontend/src/stories/PortfolioContact.stories.tsx
+++ b/frontend/src/stories/PortfolioContact.stories.tsx
@@ -1,0 +1,43 @@
+import { Story, Meta } from "@storybook/react";
+import PortfolioContact from "../components/PortfolioContact/PortfolioContact";
+import IconParameter from "../models/IconParameter";
+
+export default {
+  title: "Example/PortfolioContact",
+  component: PortfolioContact,
+  argTypes: {
+    contactHeaderTitle: { control: "text" },
+    contactIcons: {
+      types: "array",
+    },
+  },
+} as Meta;
+
+type ContactPrams = {
+  contactHeaderTitle: String;
+  contentIcons: IconParameter[];
+  contentText: String;
+};
+
+const mockContentIcons = [
+  {
+    iconName: "test",
+    contentUrl: "",
+    iconImagePath: "./logo192.png",
+  },
+  {
+    iconName: "test2",
+    contentUrl: "",
+    iconImagePath: "./logo192.png",
+  },
+];
+
+const Template: Story<ContactPrams> = (args) => (
+  <PortfolioContact {...args}> /</PortfolioContact>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  contactHeaderTitle: "TestContactTitle",
+  contentIcons: mockContentIcons,
+};

--- a/frontend/src/stories/PortfolioContact.stories.tsx
+++ b/frontend/src/stories/PortfolioContact.stories.tsx
@@ -25,7 +25,7 @@ type ContactPrams = {
 const mockContentIcons = [
   {
     iconName: "test",
-    contentUrl: "",
+    contentUrl: "https://github.com/kouta0530",
     iconImagePath: "./logo192.png",
   },
   {


### PR DESCRIPTION
## 概要
[コンタクトコンポーネント](https://github.com/kouta0530/my-portfolio/issues/2)の作成

|名前|イメージ|
|---|---|
| 実装後 | ![Screenshot from 2021-06-06 22-04-06](https://user-images.githubusercontent.com/38244340/120925651-7c15aa00-c714-11eb-857e-cce10dfd264c.png)|

## 要件
- [x] 各利用コンテンツと宛先を表示することができる
- [x] アイコンを押下すると各コンテンツに遷移することができる