### PR TITLE
feat(components): プロフィールコンポーネントの作成

### DIFF
--- a/frontend/src/components/PortfolioProfile/PortfolioProfile.tsx
+++ b/frontend/src/components/PortfolioProfile/PortfolioProfile.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import IconParameter from "../../models/IconParameter";
 import HobbyParameter from "../../models/HobbyParameter";
 import Avatar from "@material-ui/core/Avatar";
+import Paper from "@material-ui/core/Paper";
 import { makeStyles, createStyles, Theme } from "@material-ui/core/styles";
 import "./style.scss";
 
@@ -14,8 +15,8 @@ export interface ProfileProps {
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     large: {
-      width: theme.spacing(7),
-      height: theme.spacing(7),
+      width: theme.spacing(10),
+      height: theme.spacing(10),
     },
   })
 );
@@ -32,7 +33,7 @@ export const PortfolioProfile: React.FC<ProfileProps> = ({ ...props }) => {
             className={classes.large}
           ></Avatar>
         </div>
-        <div className="profile-info">
+        <Paper className="profile-info">
           <h3>{props.myName}</h3>
           <div>
             {props.myHobbyList?.map((e) => (
@@ -48,7 +49,7 @@ export const PortfolioProfile: React.FC<ProfileProps> = ({ ...props }) => {
               </>
             ))}
           </div>
-        </div>
+        </Paper>
       </div>
     </>
   );

--- a/frontend/src/components/PortfolioProfile/PortfolioProfile.tsx
+++ b/frontend/src/components/PortfolioProfile/PortfolioProfile.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import IconParameter from "../../models/IconParameter";
 import HobbyParameter from "../../models/HobbyParameter";
+import Avatar from "@material-ui/core/Avatar";
+import { makeStyles, createStyles, Theme } from "@material-ui/core/styles";
 import "./style.scss";
 
 export interface ProfileProps {
@@ -9,25 +11,40 @@ export interface ProfileProps {
   myHobbyList?: HobbyParameter[];
 }
 
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    large: {
+      width: theme.spacing(7),
+      height: theme.spacing(7),
+    },
+  })
+);
+
 export const PortfolioProfile: React.FC<ProfileProps> = ({ ...props }) => {
+  const classes = useStyles();
+
   return (
     <>
       <div className="profile">
-        <img
-          src={props.myPicture?.iconImagePath}
-          alt={props.myPicture?.iconName}
-        ></img>
+        <div className="profile-avatar">
+          <Avatar
+            src={props.myPicture?.iconImagePath}
+            className={classes.large}
+          ></Avatar>
+        </div>
         <div className="profile-info">
           <h3>{props.myName}</h3>
-          <div className="profile-info-hobbies">
+          <div>
             {props.myHobbyList?.map((e) => (
               <>
-                <h4>{e.hobbyName}</h4>
-                <ul>
-                  {e.hobbiesExampleInformation.map((e) => (
-                    <li>{e}</li>
-                  ))}
-                </ul>
+                <div>
+                  <h4 className="profile-info-hobbies">{e.hobbyName}</h4>
+                  <ul className="profile-info-hobbies-example">
+                    {e.hobbiesExampleInformation.map((e) => (
+                      <li>{e}</li>
+                    ))}
+                  </ul>
+                </div>
               </>
             ))}
           </div>

--- a/frontend/src/components/PortfolioProfile/PortfolioProfile.tsx
+++ b/frontend/src/components/PortfolioProfile/PortfolioProfile.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import IconParameter from "../../models/IconParameter";
+import HobbyParameter from "../../models/HobbyParameter";
+
+export interface ProfileProps {
+  myPicture?: IconParameter;
+  myName: string;
+  myHobbyList?: HobbyParameter[];
+}
+
+export const PortfolioProfile: React.FC<ProfileProps> = ({ ...props }) => {
+  return (
+    <>
+      <div>
+        <img
+          src={props.myPicture?.iconImagePath}
+          alt={props.myPicture?.iconName}
+        ></img>
+        <div>
+          <h3>{props.myName}</h3>
+          <div>
+            {props.myHobbyList?.map((e) => (
+              <>
+                <h4>{e.hobbyName}</h4>
+                <div>{e.hobbiesExampleInformation}</div>
+              </>
+            ))}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/frontend/src/components/PortfolioProfile/PortfolioProfile.tsx
+++ b/frontend/src/components/PortfolioProfile/PortfolioProfile.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import IconParameter from "../../models/IconParameter";
 import HobbyParameter from "../../models/HobbyParameter";
+import "./style.scss";
 
 export interface ProfileProps {
   myPicture?: IconParameter;
@@ -11,18 +12,22 @@ export interface ProfileProps {
 export const PortfolioProfile: React.FC<ProfileProps> = ({ ...props }) => {
   return (
     <>
-      <div>
+      <div className="profile">
         <img
           src={props.myPicture?.iconImagePath}
           alt={props.myPicture?.iconName}
         ></img>
-        <div>
+        <div className="profile-info">
           <h3>{props.myName}</h3>
-          <div>
+          <div className="profile-info-hobbies">
             {props.myHobbyList?.map((e) => (
               <>
                 <h4>{e.hobbyName}</h4>
-                <div>{e.hobbiesExampleInformation}</div>
+                <ul>
+                  {e.hobbiesExampleInformation.map((e) => (
+                    <li>{e}</li>
+                  ))}
+                </ul>
               </>
             ))}
           </div>

--- a/frontend/src/components/PortfolioProfile/style.scss
+++ b/frontend/src/components/PortfolioProfile/style.scss
@@ -5,18 +5,25 @@
     margin: auto 10px;
     padding: 10px;
   }
+  &-info {
+    width: 500px;
 
-  &-info-hobbies {
-    margin-left: 20px;
-    &-example {
-      display: none;
-      li {
-        display: block;
-      }
+    h3 {
+      margin-left: 10px;
     }
 
-    &:hover + &-example {
-      display: block;
+    &-hobbies {
+      margin-left: 20px;
+      &-example {
+        display: none;
+        li {
+          display: block;
+        }
+      }
+
+      &:hover + &-example {
+        display: block;
+      }
     }
   }
 }

--- a/frontend/src/components/PortfolioProfile/style.scss
+++ b/frontend/src/components/PortfolioProfile/style.scss
@@ -1,7 +1,22 @@
 .profile {
   display: flex;
 
-  img {
-    margin: 0 10px;
+  &-avatar {
+    margin: auto 10px;
+    padding: 10px;
+  }
+
+  &-info-hobbies {
+    margin-left: 20px;
+    &-example {
+      display: none;
+      li {
+        display: block;
+      }
+    }
+
+    &:hover + &-example {
+      display: block;
+    }
   }
 }

--- a/frontend/src/components/PortfolioProfile/style.scss
+++ b/frontend/src/components/PortfolioProfile/style.scss
@@ -1,0 +1,7 @@
+.profile {
+  display: flex;
+
+  img {
+    margin: 0 10px;
+  }
+}

--- a/frontend/src/models/HobbyParameter.ts
+++ b/frontend/src/models/HobbyParameter.ts
@@ -1,0 +1,4 @@
+export default interface HobbyParameter {
+  hobbyName: string;
+  hobbiesExampleInformation: string[];
+}

--- a/frontend/src/stories/PortfolioProfile.stories.tsx
+++ b/frontend/src/stories/PortfolioProfile.stories.tsx
@@ -1,0 +1,93 @@
+import { Story, Meta } from "@storybook/react";
+import {
+  PortfolioProfile,
+  ProfileProps,
+} from "../components/PortfolioProfile/PortfolioProfile";
+import IconParameter from "../models/IconParameter";
+import HobbyParameter from "../models/HobbyParameter";
+
+export default {
+  title: "Example/PortfolioProfile",
+  component: PortfolioProfile,
+} as Meta;
+
+const Template: Story<ProfileProps> = (args) => <PortfolioProfile {...args} />;
+
+export const Default = Template.bind({});
+
+Default.args = {
+  myPicture: {
+    iconImagePath: "logo192.png",
+    iconName: "saki",
+    contentUrl: "",
+  },
+  myName: "Saki",
+  myHobbyList: [
+    {
+      hobbyName: "カラオケ",
+      hobbiesExampleInformation: ["test", "テスト"],
+    },
+    {
+      hobbyName: "将棋",
+      hobbiesExampleInformation: ["test"],
+    },
+  ],
+};
+
+export const NoPictureAndNoHobby = Template.bind({});
+NoPictureAndNoHobby.args = {
+  myPicture: {
+    iconImagePath: "",
+    iconName: "saki",
+    contentUrl: "",
+  },
+  myName: "saki",
+};
+
+export const ManyInfo = Template.bind({});
+ManyInfo.args = {
+  myName: "saki",
+  myHobbyList: [
+    {
+      hobbyName: "test1",
+      hobbiesExampleInformation: [],
+    },
+    {
+      hobbyName: "test2",
+      hobbiesExampleInformation: [],
+    },
+    {
+      hobbyName: "test3",
+      hobbiesExampleInformation: [],
+    },
+    {
+      hobbyName: "test4",
+      hobbiesExampleInformation: [],
+    },
+    {
+      hobbyName: "test5",
+      hobbiesExampleInformation: [],
+    },
+  ],
+};
+
+export const ManyHobbiesExampleInfo = Template.bind({});
+ManyHobbiesExampleInfo.args = {
+  myName: "saki",
+  myHobbyList: [
+    {
+      hobbyName: "test",
+      hobbiesExampleInformation: [
+        "test1",
+        "test2",
+        "test3",
+        "test4",
+        "test5",
+        "test6",
+        "test7",
+        "test8",
+        "test9",
+      ],
+    },
+  ],
+};

--- a/frontend/src/stories/PortfolioProfile.stories.tsx
+++ b/frontend/src/stories/PortfolioProfile.stories.tsx
@@ -9,6 +9,17 @@ import HobbyParameter from "../models/HobbyParameter";
 export default {
   title: "Example/PortfolioProfile",
   component: PortfolioProfile,
+  argTypes: {
+    myPicture: {
+      control: "object",
+    },
+    myName: {
+      control: "text",
+    },
+    myHobbyList: {
+      control: "array",
+    },
+  },
 } as Meta;
 
 const Template: Story<ProfileProps> = (args) => <PortfolioProfile {...args} />;


### PR DESCRIPTION
## 概要
[プロフィールコンポーネント](https://github.com/kouta0530/my-portfolio/issues/5)を作成

| 名前 | イメージ |
|---|---|
| 実装後 | ![Peek 2021-06-12 18-35](https://user-images.githubusercontent.com/38244340/121771887-1a8a8b00-cbad-11eb-8a20-0cc8eecb3fd7.gif) |

## 要件
- [x] 自分の写真を表示することができる
- [x] 名前を表示することができる
- [x] 趣味一覧を表示することができる
- [x] 趣味一覧をホバーした時、具体例を浮かべる
