### PR TITLE
feat(components): SkillおよびSkillGroupコンポーネントの作成

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.11.4",
+    "@material-ui/icons": "^4.11.2",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "@types/node": "^12.0.0",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
+    "axios": "^0.21.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "4.0.3",

--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -1,0 +1,21 @@
+import axios from "axios";
+
+axios.create({
+  baseURL: "",
+  headers: {
+    "Content-Type": "application/json",
+    "X-Requested-With": "XMLHttpRequest",
+  },
+  responseType: "json",
+});
+
+export const get = <T>(url: string, options?: any) => {
+  const data = axios.get<T>(url, options).then(
+    (res) => res.data,
+    (err) => {
+      console.log(err);
+    }
+  );
+
+  return data;
+};

--- a/frontend/src/api/portfolioSkillsAPI.ts
+++ b/frontend/src/api/portfolioSkillsAPI.ts
@@ -1,0 +1,14 @@
+import SkillParameter from "../models/SkillParameter";
+import { get } from "./http";
+
+export const getPortfolioSkillList = async () => {
+  return await get<SkillParameter[]>("/v1/skills");
+};
+
+export const getPortfolioSkill = async (id: Number) => {
+  return await get<SkillParameter>(`/v1/skills/${id}`);
+};
+
+export const getPortfolioSkillTypeList = async () => {
+  return await get<string[]>(`/v1/skills/type`);
+};

--- a/frontend/src/components/PortfolioSkill/PortfolioSkill.tsx
+++ b/frontend/src/components/PortfolioSkill/PortfolioSkill.tsx
@@ -8,7 +8,9 @@ export interface SkillProp {
 }
 
 export const PortfolioSkill: React.FC<SkillProp> = ({ ...props }) => {
-  const stars = Array(props.skillInformation.skilledStars).fill(<StarIcon />);
+  const stars = Array(props.skillInformation.skilledStars).fill(
+    <StarIcon color="primary" />
+  );
 
   return (
     <>

--- a/frontend/src/components/PortfolioSkill/PortfolioSkill.tsx
+++ b/frontend/src/components/PortfolioSkill/PortfolioSkill.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import SkillParameter from "../../models/SkillParameter";
+import StarIcon from "@material-ui/icons/Star";
+import "./style.scss";
+
+export interface SkillProp {
+  skillInformation: SkillParameter;
+}
+
+export const PortfolioSkill: React.FC<SkillProp> = ({ ...props }) => {
+  const stars = Array(props.skillInformation.skilledStars).fill(<StarIcon />);
+
+  return (
+    <>
+      <div className="skill">
+        <label>{props.skillInformation.skillLabel}</label>
+        <div className="skilled-stars">
+          <span className="skilled-star">{stars}</span>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/frontend/src/components/PortfolioSkill/PortfolioSkill.tsx
+++ b/frontend/src/components/PortfolioSkill/PortfolioSkill.tsx
@@ -17,9 +17,18 @@ export const PortfolioSkill: React.FC<SkillProp> = ({ ...props }) => {
   return (
     <>
       <div className="skill">
-        <label>
-          {props.skillInformation.skillLabel.replace(/(.{30}?)/g, "$&\r\n")}
-        </label>
+        <div>
+          {props.skillInformation.skillLabel.length > 20
+            ? props.skillInformation.skillLabel
+                .match(/.{0,20}/g)
+                ?.map((str, idx) => (
+                  <React.Fragment key={idx}>
+                    {str}
+                    <br />
+                  </React.Fragment>
+                ))
+            : props.skillInformation.skillLabel}
+        </div>
         <div className="skilled-stars">{stars}</div>
       </div>
     </>

--- a/frontend/src/components/PortfolioSkill/PortfolioSkill.tsx
+++ b/frontend/src/components/PortfolioSkill/PortfolioSkill.tsx
@@ -9,16 +9,16 @@ export interface SkillProp {
 
 export const PortfolioSkill: React.FC<SkillProp> = ({ ...props }) => {
   const stars = Array(props.skillInformation.skilledStars).fill(
-    <StarIcon color="primary" />
+    <span className="skilled-star">
+      <StarIcon color="primary" />
+    </span>
   );
 
   return (
     <>
       <div className="skill">
         <label>{props.skillInformation.skillLabel}</label>
-        <div className="skilled-stars">
-          <span className="skilled-star">{stars}</span>
-        </div>
+        <div className="skilled-stars">{stars}</div>
       </div>
     </>
   );

--- a/frontend/src/components/PortfolioSkill/PortfolioSkill.tsx
+++ b/frontend/src/components/PortfolioSkill/PortfolioSkill.tsx
@@ -18,9 +18,9 @@ export const PortfolioSkill: React.FC<SkillProp> = ({ ...props }) => {
     <>
       <div className="skill">
         <div className="skill-label">
-          {props.skillInformation.skillLabel.length > 20
+          {props.skillInformation.skillLabel.length > 9
             ? props.skillInformation.skillLabel
-                .match(/.{0,10}/g)
+                .match(/.{0,9}/g)
                 ?.map((str, idx) => (
                   <React.Fragment key={idx}>
                     {str}

--- a/frontend/src/components/PortfolioSkill/PortfolioSkill.tsx
+++ b/frontend/src/components/PortfolioSkill/PortfolioSkill.tsx
@@ -17,10 +17,10 @@ export const PortfolioSkill: React.FC<SkillProp> = ({ ...props }) => {
   return (
     <>
       <div className="skill">
-        <div>
+        <div className="skill-label">
           {props.skillInformation.skillLabel.length > 20
             ? props.skillInformation.skillLabel
-                .match(/.{0,20}/g)
+                .match(/.{0,10}/g)
                 ?.map((str, idx) => (
                   <React.Fragment key={idx}>
                     {str}

--- a/frontend/src/components/PortfolioSkill/PortfolioSkill.tsx
+++ b/frontend/src/components/PortfolioSkill/PortfolioSkill.tsx
@@ -17,7 +17,9 @@ export const PortfolioSkill: React.FC<SkillProp> = ({ ...props }) => {
   return (
     <>
       <div className="skill">
-        <label>{props.skillInformation.skillLabel}</label>
+        <label>
+          {props.skillInformation.skillLabel.replace(/(.{30}?)/g, "$&\r\n")}
+        </label>
         <div className="skilled-stars">{stars}</div>
       </div>
     </>

--- a/frontend/src/components/PortfolioSkill/style.scss
+++ b/frontend/src/components/PortfolioSkill/style.scss
@@ -1,7 +1,8 @@
 .skill {
   display: flex;
+  margin: 16px;
   &-label {
-    max-width: 170px;
+    width: 120px;
   }
   .skilled-stars {
     margin-left: 16px;

--- a/frontend/src/components/PortfolioSkill/style.scss
+++ b/frontend/src/components/PortfolioSkill/style.scss
@@ -1,0 +1,6 @@
+.skill {
+  display: flex;
+  .skilled-star {
+    margin: 0 16px;
+  }
+}

--- a/frontend/src/components/PortfolioSkill/style.scss
+++ b/frontend/src/components/PortfolioSkill/style.scss
@@ -1,7 +1,11 @@
 .skill {
   display: flex;
+  &-label {
+    max-width: 170px;
+  }
   .skilled-stars {
     margin-left: 16px;
+    width: 100px;
     .skilled-star {
       margin-right: 4px;
     }

--- a/frontend/src/components/PortfolioSkill/style.scss
+++ b/frontend/src/components/PortfolioSkill/style.scss
@@ -1,6 +1,9 @@
 .skill {
   display: flex;
-  .skilled-star {
-    margin: 0 16px;
+  .skilled-stars {
+    margin-left: 16px;
+    .skilled-star {
+      margin-right: 4px;
+    }
   }
 }

--- a/frontend/src/components/PortfolioSkillGroup/PortfolioSkillGroup.tsx
+++ b/frontend/src/components/PortfolioSkillGroup/PortfolioSkillGroup.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import SkillParameter from "../../models/SkillParameter";
 import { PortfolioSkill } from "../PortfolioSkill/PortfolioSkill";
+import { Card, CardContent, Typography } from "@material-ui/core";
+import "./style.scss";
 
 export interface SkillGroupProp {
   skillTypes: string[];
@@ -10,16 +12,20 @@ export interface SkillGroupProp {
 export const PortfolioSkillGroup: React.FC<SkillGroupProp> = ({ ...props }) => {
   return (
     <>
-      {props.skillTypes.map((skillType) => (
-        <div>
-          <p>{skillType}</p>
-          {props.skillInformation
-            .filter((skill) => skill.type === skillType)
-            .map((s) => (
-              <PortfolioSkill skillInformation={s} />
-            ))}
-        </div>
-      ))}
+      <div className="skill-group">
+        {props.skillTypes.map((skillType) => (
+          <Card className="skill">
+            <CardContent>
+              <Typography component="p">{skillType}</Typography>
+              {props.skillInformation
+                .filter((skill) => skill.type === skillType)
+                .map((s) => (
+                  <PortfolioSkill skillInformation={s} />
+                ))}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
     </>
   );
 };

--- a/frontend/src/components/PortfolioSkillGroup/PortfolioSkillGroup.tsx
+++ b/frontend/src/components/PortfolioSkillGroup/PortfolioSkillGroup.tsx
@@ -14,9 +14,11 @@ export const PortfolioSkillGroup: React.FC<SkillGroupProp> = ({ ...props }) => {
     <>
       <div className="skill-group">
         {props.skillTypes.map((skillType) => (
-          <Card className="skill">
+          <Card className="skill-group-card">
             <CardContent>
-              <Typography component="p">{skillType}</Typography>
+              <Typography component="p" className="skill-group-card-label">
+                {skillType}
+              </Typography>
               {props.skillInformation
                 .filter((skill) => skill.type === skillType)
                 .map((s) => (

--- a/frontend/src/components/PortfolioSkillGroup/PortfolioSkillGroup.tsx
+++ b/frontend/src/components/PortfolioSkillGroup/PortfolioSkillGroup.tsx
@@ -16,7 +16,11 @@ export const PortfolioSkillGroup: React.FC<SkillGroupProp> = ({ ...props }) => {
         {props.skillTypes.map((skillType) => (
           <Card className="skill-group-card">
             <CardContent>
-              <Typography component="p" className="skill-group-card-label">
+              <Typography
+                component="p"
+                align="center"
+                className="skill-group-card-label"
+              >
                 {skillType}
               </Typography>
               {props.skillInformation

--- a/frontend/src/components/PortfolioSkillGroup/PortfolioSkillGroup.tsx
+++ b/frontend/src/components/PortfolioSkillGroup/PortfolioSkillGroup.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import SkillGroupParameter from "../../models/SkillGroupParameter";
+import { PortfolioSkill } from "../PortfolioSkill/PortfolioSkill";
+
+export interface SkillGroupProp {
+  skillTypes: string[];
+  skillInformation: SkillGroupParameter;
+}
+
+export const PortfolioSkillGroup: React.FC<SkillGroupProp> = ({ ...props }) => {
+  return (
+    <>
+      {props.skillInformation.skillInformationMatchTypesKey.map((e) => (
+        <PortfolioSkill skillInformation={e} />
+      ))}
+    </>
+  );
+};

--- a/frontend/src/components/PortfolioSkillGroup/PortfolioSkillGroup.tsx
+++ b/frontend/src/components/PortfolioSkillGroup/PortfolioSkillGroup.tsx
@@ -1,17 +1,24 @@
 import React from "react";
-import SkillGroupParameter from "../../models/SkillGroupParameter";
+import SkillParameter from "../../models/SkillParameter";
 import { PortfolioSkill } from "../PortfolioSkill/PortfolioSkill";
 
 export interface SkillGroupProp {
   skillTypes: string[];
-  skillInformation: SkillGroupParameter;
+  skillInformation: SkillParameter[];
 }
 
 export const PortfolioSkillGroup: React.FC<SkillGroupProp> = ({ ...props }) => {
   return (
     <>
-      {props.skillInformation.skillInformationMatchTypesKey.map((e) => (
-        <PortfolioSkill skillInformation={e} />
+      {props.skillTypes.map((skillType) => (
+        <div>
+          <p>{skillType}</p>
+          {props.skillInformation
+            .filter((skill) => skill.type === skillType)
+            .map((s) => (
+              <PortfolioSkill skillInformation={s} />
+            ))}
+        </div>
       ))}
     </>
   );

--- a/frontend/src/components/PortfolioSkillGroup/style.scss
+++ b/frontend/src/components/PortfolioSkillGroup/style.scss
@@ -1,0 +1,7 @@
+.skill-group {
+  display: flex;
+  .skill {
+    margin: 16px;
+    width: 300px;
+  }
+}

--- a/frontend/src/components/PortfolioSkillGroup/style.scss
+++ b/frontend/src/components/PortfolioSkillGroup/style.scss
@@ -1,8 +1,13 @@
 .skill-group {
   display: flex;
   flex-wrap: wrap;
-  .skill {
+
+  .skill-group-card {
     margin: 16px;
-    width: 280px;
+    width: 300px;
+    min-height: 200px;
+    &-label {
+      margin: 16px 0;
+    }
   }
 }

--- a/frontend/src/components/PortfolioSkillGroup/style.scss
+++ b/frontend/src/components/PortfolioSkillGroup/style.scss
@@ -1,7 +1,8 @@
 .skill-group {
   display: flex;
+  flex-wrap: wrap;
   .skill {
     margin: 16px;
-    width: 300px;
+    width: 280px;
   }
 }

--- a/frontend/src/models/SkillGroupParameter.ts
+++ b/frontend/src/models/SkillGroupParameter.ts
@@ -1,0 +1,6 @@
+import SkillParameter from "./SkillParameter";
+
+export default interface SkillGroupParameter {
+  skillTypesKey: string;
+  skillInformationMatchTypesKey: SkillParameter[];
+}

--- a/frontend/src/models/SkillParameter.ts
+++ b/frontend/src/models/SkillParameter.ts
@@ -1,0 +1,5 @@
+export default interface SkillParameter {
+  skillLabel: string;
+  skilledStars: number;
+  type: string;
+}

--- a/frontend/src/stories/PortfolioSkill.stories.tsx
+++ b/frontend/src/stories/PortfolioSkill.stories.tsx
@@ -29,3 +29,13 @@ ManyStars.args = {
     type: "test",
   },
 };
+
+export const LongLabel = Template.bind({});
+LongLabel.args = {
+  skillInformation: {
+    skillLabel:
+      "veryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylongveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylongLabel",
+    skilledStars: 3,
+    type: "test",
+  },
+};

--- a/frontend/src/stories/PortfolioSkill.stories.tsx
+++ b/frontend/src/stories/PortfolioSkill.stories.tsx
@@ -20,3 +20,12 @@ Default.args = {
     type: "test",
   },
 };
+
+export const ManyStars = Template.bind({});
+ManyStars.args = {
+  skillInformation: {
+    skillLabel: "manyStars",
+    skilledStars: 100,
+    type: "test",
+  },
+};

--- a/frontend/src/stories/PortfolioSkill.stories.tsx
+++ b/frontend/src/stories/PortfolioSkill.stories.tsx
@@ -1,0 +1,22 @@
+import { Story, Meta } from "@storybook/react";
+import {
+  PortfolioSkill,
+  SkillProp,
+} from "../components/PortfolioSkill/PortfolioSkill";
+
+export default {
+  title: "Example/PortfolioSkill",
+  component: PortfolioSkill,
+  argTypes: {},
+} as Meta;
+
+const Template: Story<SkillProp> = (args) => <PortfolioSkill {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  skillInformation: {
+    skillLabel: "testLabel",
+    skilledStars: 3,
+    type: "test",
+  },
+};

--- a/frontend/src/stories/PortfolioSkillGroup.stories.tsx
+++ b/frontend/src/stories/PortfolioSkillGroup.stories.tsx
@@ -3,6 +3,7 @@ import {
   PortfolioSkillGroup,
   SkillGroupProp,
 } from "../components/PortfolioSkillGroup/PortfolioSkillGroup";
+import { ManyStars } from "./PortfolioSkill.stories";
 
 export default {
   title: "Example/PortfolioSkillGroup",
@@ -77,6 +78,23 @@ DiffrentLengthLabel.args = {
     },
     {
       skillLabel: "あああああああああああああああああああああああああ",
+      skilledStars: 2,
+      type: "test",
+    },
+  ],
+};
+
+export const ManyStarsCardView = Template.bind({});
+ManyStarsCardView.args = {
+  skillTypes: ["test"],
+  skillInformation: [
+    {
+      skillLabel: "manyStars",
+      skilledStars: 30,
+      type: "test",
+    },
+    {
+      skillLabel: "eeeee",
       skilledStars: 2,
       type: "test",
     },

--- a/frontend/src/stories/PortfolioSkillGroup.stories.tsx
+++ b/frontend/src/stories/PortfolioSkillGroup.stories.tsx
@@ -59,3 +59,26 @@ Default.args = {
 
 export const ManyKindsSkills = Template.bind({});
 ManyKindsSkills.args = { ...manyKindsMockData };
+
+export const DiffrentLengthLabel = Template.bind({});
+
+DiffrentLengthLabel.args = {
+  skillTypes: ["test"],
+  skillInformation: [
+    {
+      skillLabel: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      skilledStars: 2,
+      type: "test",
+    },
+    {
+      skillLabel: "eeeee",
+      skilledStars: 2,
+      type: "test",
+    },
+    {
+      skillLabel: "あああああああああああああああああああああああああ",
+      skilledStars: 2,
+      type: "test",
+    },
+  ],
+};

--- a/frontend/src/stories/PortfolioSkillGroup.stories.tsx
+++ b/frontend/src/stories/PortfolioSkillGroup.stories.tsx
@@ -31,6 +31,23 @@ const mockSkillGroupData = {
   ],
 };
 
+const manyKindsMockData = {
+  skillTypes: [...mockSkillGroupData.skillTypes, "ミドルウェア", "その他"],
+  skillInformation: [
+    ...mockSkillGroupData.skillInformation,
+    {
+      skillLabel: "Apache",
+      skilledStars: 2,
+      type: "ミドルウェア",
+    },
+    {
+      skillLabel: "TOEIC",
+      skilledStars: 3,
+      type: "その他",
+    },
+  ],
+};
+
 const Template: Story<SkillGroupProp> = (args) => (
   <PortfolioSkillGroup {...args} />
 );
@@ -39,3 +56,6 @@ export const Default = Template.bind({});
 Default.args = {
   ...mockSkillGroupData,
 };
+
+export const ManyKindsSkills = Template.bind({});
+ManyKindsSkills.args = { ...manyKindsMockData };

--- a/frontend/src/stories/PortfolioSkillGroup.stories.tsx
+++ b/frontend/src/stories/PortfolioSkillGroup.stories.tsx
@@ -1,0 +1,41 @@
+import { Story, Meta } from "@storybook/react";
+import {
+  PortfolioSkillGroup,
+  SkillGroupProp,
+} from "../components/PortfolioSkillGroup/PortfolioSkillGroup";
+
+export default {
+  title: "Example/PortfolioSkillGroup",
+  component: PortfolioSkillGroup,
+  argTypes: {},
+} as Meta;
+
+const mockSkillGroupData = {
+  skillTypes: ["フロントエンド", "バックエンド"],
+  skillInformation: [
+    {
+      skillLabel: "Vue.js",
+      skilledStars: 3,
+      type: "フロントエンド",
+    },
+    {
+      skillLabel: "React.js",
+      skilledStars: 3,
+      type: "フロントエンド",
+    },
+    {
+      skillLabel: "Python",
+      skilledStars: 3,
+      type: "バックエンド",
+    },
+  ],
+};
+
+const Template: Story<SkillGroupProp> = (args) => (
+  <PortfolioSkillGroup {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  ...mockSkillGroupData,
+};

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3849,6 +3849,13 @@ axe-core@^4.0.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.2.1.tgz#2e50bcf10ee5b819014f6e342e41e45096239e34"
   integrity sha512-evY7DN8qSIbsW2H/TWQ1bX3sXN1d4MNb5Vb4n7BzPuCwRHdkZ1H2eNLuSh73EoQqkGKUtju2G2HCcjCfhvZIAA==
 
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+  dependencies:
+    follow-redirects "^1.10.0"
+
 axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
@@ -6921,7 +6928,7 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-follow-redirects@^1.0.0:
+follow-redirects@^1.0.0, follow-redirects@^1.10.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.1.tgz#d9114ded0a1cfdd334e164e6662ad02bfd91ff43"
   integrity sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1696,6 +1696,13 @@
     react-is "^16.8.0 || ^17.0.0"
     react-transition-group "^4.4.0"
 
+"@material-ui/icons@^4.11.2":
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-4.11.2.tgz#b3a7353266519cd743b6461ae9fdfcb1b25eb4c5"
+  integrity sha512-fQNsKX2TxBmqIGJCSi3tGTO/gZ+eJgWmMJkgDiOfyNaunNaxcklJQFaFogYcFl0qFuaEz1qaXYXboa/bUXVSOQ==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+
 "@material-ui/styles@^4.11.4":
   version "4.11.4"
   resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.11.4.tgz#eb9dfccfcc2d208243d986457dff025497afa00d"


### PR DESCRIPTION
## 概要
[所持スキルの可視化](https://github.com/kouta0530/my-portfolio/issues/7)を行うためのコンポーネントの実装

| 名前 | イメージ |
|---|---|
| スキルの可視化| ![Screenshot from 2021-06-26 14-09-04](https://user-images.githubusercontent.com/38244340/123509016-116de380-d6ae-11eb-84aa-3827b1b49615.png) |
| カテゴリ別の可視化| ![Screenshot from 2021-06-26 14-09-25](https://user-images.githubusercontent.com/38244340/123509023-1fbbff80-d6ae-11eb-8a3b-92af4e46298d.png)|

## 要件
* 単体
- [x] スキル名を表示することができる
- [x] Propに対応する数のスターアイコンを表示することができる

* 複数
- [x] カテゴリごとにスキルを表示することができる

## 補足
API関連のテスト・修正はサーバー側の実装が完了次第行う
